### PR TITLE
Fix datasource CLI syntax

### DIFF
--- a/docker/start-wildfly.sh
+++ b/docker/start-wildfly.sh
@@ -30,18 +30,9 @@ if ! /opt/jboss/wildfly/bin/jboss-cli.sh --connect --command="/subsystem=datasou
 fi
 
 # Adicionar datasource (ignora se já existe)
-/opt/jboss/wildfly/bin/jboss-cli.sh --connect <<EOF
+/opt/jboss/wildfly/bin/jboss-cli.sh --connect <<'EOF'
 if (outcome != success) of /subsystem=datasources/data-source=PostgreSQLDS:read-resource
-  data-source add --jndi-name=java:jboss/datasources/PostgreSQLDS \
-                  --name=PostgreSQLDS \
-                  --connection-url=jdbc:postgresql://postgres:5432/apidb \
-                  --driver-name=postgresql \
-                  --user-name=apiuser \
-                  --password=apipass \
-                  --validate-on-match=true \
-                  --background-validation=false \
-                  --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker \
-                  --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter
+  data-source add --jndi-name=java:jboss/datasources/PostgreSQLDS --name=PostgreSQLDS --connection-url=jdbc:postgresql://postgres:5432/apidb --driver-name=postgresql --user-name=apiuser --password=apipass --validate-on-match=true --background-validation=false --valid-connection-checker-class-name=org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker --exception-sorter-class-name=org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter
 end-if
 EOF
 


### PR DESCRIPTION
## Summary
- ensure WildFly CLI script adds PostgreSQL datasource without shell line continuation characters

## Testing
- `./validate-project.sh`
- `mvn -q -ntp test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5eadfcb5c8325bc3ebe803ccc5223