### PR TITLE
Fix PostgreSQL driver module for Jakarta

### DIFF
--- a/docker/setup-datasource.cli
+++ b/docker/setup-datasource.cli
@@ -1,7 +1,7 @@
 # Configuração do datasource PostgreSQL para WildFly
 
 # Adicionar módulo PostgreSQL
-module add --name=org.postgresql --resources=/opt/jboss/wildfly/postgresql-42.6.0.jar --dependencies=javax.api,javax.transaction.api
+module add --name=org.postgresql --resources=/opt/jboss/wildfly/postgresql-42.6.0.jar --dependencies=jakarta.api,jakarta.transaction.api
 
 # Adicionar driver PostgreSQL
 /subsystem=datasources/jdbc-driver=postgresql:add(driver-name="postgresql",driver-module-name="org.postgresql",driver-class-name=org.postgresql.Driver)

--- a/docker/start-wildfly.sh
+++ b/docker/start-wildfly.sh
@@ -21,7 +21,7 @@ echo "Configurando datasource PostgreSQL..."
 
 # Adicionar módulo PostgreSQL (ignora erro se já existir)
 if ! /opt/jboss/wildfly/bin/jboss-cli.sh --connect --command="module info org.postgresql" >/dev/null 2>&1; then
-  /opt/jboss/wildfly/bin/jboss-cli.sh --connect --command="module add --name=org.postgresql --resources=/opt/jboss/wildfly/postgresql-42.6.0.jar --dependencies=jakarta.api,javax.transaction.api"
+  /opt/jboss/wildfly/bin/jboss-cli.sh --connect --command="module add --name=org.postgresql --resources=/opt/jboss/wildfly/postgresql-42.6.0.jar --dependencies=jakarta.api,jakarta.transaction.api"
 fi
 
 # Adicionar driver PostgreSQL (ignora se já existe)


### PR DESCRIPTION
## Summary
- use Jakarta EE module names when adding PostgreSQL driver
- ensure CLI scripts reference correct jakarta.transaction API

## Testing
- `./validate-project.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b5f0b5a15883259e606cb27a50e740