### PR TITLE
Expose OpenAPI docs under swagger path

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Esta é uma API REST completa desenvolvida com JBoss/WildFly e PostgreSQL, utili
 
 5. **Acesse a aplicação**
    - Interface principal: http://localhost:8080/jboss-api
-   - API OpenAPI JSON: http://localhost:8080/jboss-api/api/openapi.json
-   - Swagger UI: https://petstore.swagger.io/?url=http://localhost:8080/jboss-api/api/openapi.json
+   - API OpenAPI JSON: http://localhost:8080/jboss-api/swagger
+   - Swagger UI: https://petstore.swagger.io/?url=http://localhost:8080/jboss-api/swagger
 
 ## 📡 Endpoints da API
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -18,19 +18,18 @@
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     
-    <!-- Swagger UI -->
+    <!-- OpenAPI servlet para expor a documentação -->
     <servlet>
-        <servlet-name>SwaggerUIServlet</servlet-name>
-        <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
+        <servlet-name>OpenApiServlet</servlet-name>
+        <servlet-class>io.swagger.v3.jaxrs2.integration.servlet.OpenApiServlet</servlet-class>
         <init-param>
-            <param-name>jersey.config.server.provider.packages</param-name>
-            <param-value>io.swagger.v3.jaxrs2.integration.resources</param-value>
+            <param-name>openApiConfiguration.resourcePackages</param-name>
+            <param-value>com.example.api.resource</param-value>
         </init-param>
-        <load-on-startup>1</load-on-startup>
     </servlet>
-    
+
     <servlet-mapping>
-        <servlet-name>SwaggerUIServlet</servlet-name>
+        <servlet-name>OpenApiServlet</servlet-name>
         <url-pattern>/swagger/*</url-pattern>
     </servlet-mapping>
     

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -62,8 +62,8 @@
         </div>
         
         <div class="links">
-            <a href="/jboss-api/api/openapi.json" class="btn">📄 OpenAPI JSON</a>
-            <a href="https://petstore.swagger.io/?url=http://localhost:8080/jboss-api/api/openapi.json" class="btn" target="_blank">📚 Swagger UI</a>
+            <a href="/jboss-api/swagger" class="btn">📄 OpenAPI JSON</a>
+            <a href="https://petstore.swagger.io/?url=http://localhost:8080/jboss-api/swagger" class="btn" target="_blank">📚 Swagger UI</a>
         </div>
         
         <div class="info">


### PR DESCRIPTION
## Summary
- serve OpenAPI docs through `OpenApiServlet` at `/swagger/*`
- point README and landing page to the new Swagger endpoint

## Testing
- `./validate-project.sh`
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f40f52c08325bc26ddf3c84bcd08