### PR TITLE
Fix Swagger initializer artifact id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
-            <artifactId>swagger-jaxrs2-jakarta-servlet-initializer</artifactId>
+            <artifactId>swagger-jaxrs2-servlet-initializer-jakarta</artifactId>
             <version>2.2.15</version>
         </dependency>
 


### PR DESCRIPTION
## Summary
- correct Swagger servlet initializer artifact id

## Testing
- `mvn clean package -DskipTests` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-clean-plugin:pom:3.2.0: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b600c4de94832595b9c228555aba08